### PR TITLE
Add different groups of dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "itmo-ics-printf"
-version = "0.1.0"
+version = "0.2.0"
 description = "Visualisation and analysation tool for 'scanf' - FreeRTOS profiler grabber"
 authors = [
     { name = "Alexander Nalobin" },
@@ -14,12 +14,24 @@ dependencies = []
 
 [tool.poetry]
 
+[tool.poetry.dependencies]
+python = ">=3.13"
+plotly = { version = ">=6.0.1, <7.0.0", optional = true }
+jupyterlab = { version = ">=4.4.0, <5.0.0", optional = true }
+matplotlib = { version = ">=3.7.1, <4.0.0", optional = true }
+
+[tool.poetry.extras]
+plotly = ["plotly"]
+jupyterlab = ["jupyterlab"]
+jupyterlab-matplotlib = ["jupyterlab", "matplotlib"]
+jupyterlab-plotly = ["jupyterlab", "plotly"]
+all = ["plotly", "jupyterlab", "jupyterlab-matplotlib", "jupyterlab-plotly"]
+
 [tool.poetry.group.dev.dependencies]
 icecream = "^2.1.4"
 pytest = "^8.3.5"
 pytest-cov = "^6.0.0"
-plotly = "^6.0.1"
-jupyterlab = "^4.4.0"
+
 
 [build-system]
 requires = ["poetry-core>=2.0.0,<3.0.0"]


### PR DESCRIPTION
Fix #8 
Change version from 0.1.0 to 0.2.0, add matplotlib as dependency and add different groups such as jupyterlab-plotly and jupyterlab-matplotlib